### PR TITLE
fix: correction on mode eigenvalue equation

### DIFF
--- a/ceviche_challenges/modes.py
+++ b/ceviche_challenges/modes.py
@@ -217,7 +217,7 @@ def solve_modes(
   # where E is the transverse electric field component of the eigenmode and β²
   # is the eigenvalue. β corresponds to the guided wavevector of the eigenmode.
   vals, vecs = scipy.sparse.linalg.eigs(
-      dxf.dot(dxb) + k0**2 * diag_eps_r,
+      dxb.dot(dxf) + k0**2 * diag_eps_r,
       k=order,
       v0=epsilon_r.ravel(),
       which='LR')
@@ -235,5 +235,8 @@ def solve_modes(
   # where the β term originates from the spatial derivative in the propagation
   # direction.
   h = beta / omega / constants.MU_0 * e
+  # Since the Yee grid is staggered
+  # the field accumulates a phase on a distance equal to half a cell
+  h_yee = h * np.exp(1j * dl / 2)
 
-  return e, h, beta
+  return e, h_yee, beta

--- a/ceviche_challenges/modes.py
+++ b/ceviche_challenges/modes.py
@@ -235,8 +235,5 @@ def solve_modes(
   # where the β term originates from the spatial derivative in the propagation
   # direction.
   h = beta / omega / constants.MU_0 * e
-  # Since the Yee grid is staggered
-  # the field accumulates a phase on a distance equal to half a cell
-  h_yee = h * np.exp(1j * dl / 2)
 
-  return e, h_yee, beta
+  return e, h, beta

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 setuptools.setup(
     name='ceviche_challenges',
-    version='1.0.2',
+    version='1.0.3',
     license='Apache 2.0',
     author='Google LLC',
     author_email='noreply@google.com',


### PR DESCRIPTION
This PR corrects a minor mistake on the electric-field mode solver equation ~~and introduces a correction factor for the magnetic field calculated.~~ (All the explanations will be documented below to avoid any misunderstanding and to prevent any error from my side).

Justification :
- The complete Maxwell equation without a source can be written as $\nabla \times \mu^{-1} \nabla  \times E - \omega^2 \epsilon E = 0$. By using the free space magnetic permeability, it leads us to $\nabla \times \nabla \times E - \omega^2 \mu_0 \epsilon_0 \epsilon_r E$ and thus $\nabla \times \nabla \times E - k^2 \epsilon_r E$. The first curl (on left) will be associated to the magnetic field : using the Maxwell–Faraday equation, we replace the value of the magnetic field on the Ampère's circuital law. Using the fact that on the Yee-grid, magnetic field is associated to backward differencies whereas electric field is associated to forward differencies, we obtain $dxb \times dxf  \times E - k^2 \epsilon_r E$ if we use the naming convention of the script.
- ~~Since the fields will be used on a Yee-grid, the electric and magnetic fields will be separated by a distance of half a cell, so the phase will evoluate on a distance $\frac{dl}{2}$ leading to $H_{yee} = H \exp^{j\frac{dl}{2}}$.~~

_(I already sign the CLA.)_